### PR TITLE
Fix banner output for mission modules

### DIFF
--- a/core/mission_executor.py
+++ b/core/mission_executor.py
@@ -24,10 +24,6 @@ def banner(title: str, description: str):
     print("=" * 80)
     print()
 
-banner(
-    title="Mission Executor / Исполнитель Миссий",
-    description="Загружает и выполняет пошаговые стратегические миссии."
-)
 # --- End Banner ---
 
 class MissionExecutor:
@@ -119,5 +115,9 @@ class MissionExecutor:
         print("--- Mission Complete ---")
 
 if __name__ == "__main__":
+    banner(
+        title="Mission Executor / Исполнитель Миссий",
+        description="Загружает и выполняет пошаговые стратегические миссии."
+    )
     executor = MissionExecutor()
     executor.run_mission()

--- a/core/telemetry.py
+++ b/core/telemetry.py
@@ -14,10 +14,6 @@ def banner(title: str, description: str):
     print("=" * 80)
     print()
 
-banner(
-    title="Telemetry Manager / Менеджер Телеметрии",
-    description="Управляет данными телеметрии QIKI Bot."
-)
 
 class TelemetryManager:
     DEFAULT_TELEMETRY: Dict[str, Any] = {
@@ -104,6 +100,10 @@ class TelemetryManager:
 
 # Example usage (for testing this module directly)
 if __name__ == "__main__":
+    banner(
+        title="Telemetry Manager / Менеджер Телеметрии",
+        description="Управляет данными телеметрии QIKI Bot."
+    )
     print("--- TelemetryManager Test ---")
 
     # Clean up old telemetry.json for a fresh start


### PR DESCRIPTION
## Summary
- prevent telemetry and mission modules from printing on import
- only display banner when running each module directly

## Testing
- `pip install -r requirements.txt`
- `pip install torch --extra-index-url https://download.pytorch.org/whl/cpu`
- `pip install micrograd`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'core.fsm')*

------
https://chatgpt.com/codex/tasks/task_e_687b0f43baf48331a160018180bebe13

## Summary by Sourcery

Move banner display calls into the __main__ guard for mission_executor and telemetry modules so banners no longer print on import but only when run directly.

Enhancements:
- Remove unconditional banner calls on module import for MissionExecutor and TelemetryManager
- Add banner invocation inside if __name__ == "__main__" blocks for both modules