### PR TITLE
Use FSMClient for state reading

### DIFF
--- a/tools/consistency_checker.py
+++ b/tools/consistency_checker.py
@@ -15,7 +15,7 @@ from typing import Dict, Any, List
 # Ensure the script can find the core modules
 sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
 from core.file_paths import FSM_STATE_FILE, SENSORS_FILE, TELEMETRY_FILE, MISSION_STATUS_FILE
-from core.fsm_client import read_fsm_state
+from core.fsm_client import FSMClient
 
 # --- Log Setup ---
 LOG_DIR = os.path.join(os.path.dirname(__file__), '..', 'logs')
@@ -39,6 +39,7 @@ class ConsistencyChecker:
     def __init__(self, verbose=False):
         self.verbose = verbose
         self.issues = []
+        self.fsm_client = FSMClient()
 
     def log_issue(self, level: str, check_type: str, message: str, details: Dict[str, Any]):
         """Logs a consistency issue."""
@@ -89,7 +90,7 @@ class ConsistencyChecker:
         self.issues = []
         
         # 1. Load all state files
-        fsm_state = read_fsm_state()
+        fsm_state = self.fsm_client.get_state()
         sensors = self.load_json_safely(SENSORS_FILE)
         telemetry = self.load_json_safely(TELEMETRY_FILE)
         mission = self.load_json_safely(MISSION_STATUS_FILE)

--- a/tools/fsm_debugger.py
+++ b/tools/fsm_debugger.py
@@ -12,11 +12,13 @@ import sys
 sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
 
 from core.fsm_io import enqueue_event
-from core.fsm_client import read_fsm_state
+from core.fsm_client import FSMClient
+
+fsm_client = FSMClient()
 
 def print_status():
     """Prints the current FSM state."""
-    state = read_fsm_state()
+    state = fsm_client.get_state()
     print(json.dumps(state, indent=4))
 
 def step_fsm(event):
@@ -26,7 +28,7 @@ def step_fsm(event):
 
 def list_transitions():
     """Lists the possible transitions from the current state."""
-    state = read_fsm_state()
+    state = fsm_client.get_state()
     if 'possible_transitions' in state:
         print("Possible transitions:")
         for transition in state['possible_transitions']:


### PR DESCRIPTION
## Summary
- switch consistency checker to FSMClient
- update fsm debugger to use FSMClient

## Testing
- `pytest -q` *(fails: No module named 'torch' and other modules)*

------
https://chatgpt.com/codex/tasks/task_e_687b0f41331c833193c51118e82e082e

## Summary by Sourcery

Switch state reading logic in developer tools from the deprecated read_fsm_state function to the new FSMClient interface.

Enhancements:
- Refactor fsm_debugger to instantiate FSMClient and use its get_state method instead of read_fsm_state
- Instantiate FSMClient in consistency_checker and replace direct calls to read_fsm_state with fsm_client.get_state
- Update imports in tools to import FSMClient and remove read_fsm_state