### PR TITLE
Implement sensor update error handling

### DIFF
--- a/assistant.py
+++ b/assistant.py
@@ -1,7 +1,9 @@
 import os
 import sys
+
 from core.localization_manager import loc
 from core.fsm_client import FSMClient  # Use the client to send requests
+
 
 class Assistant:
     def __init__(self):
@@ -26,7 +28,7 @@ class Assistant:
                 print(f"Sending event: {event}")
                 self.fsm_client.send_event(event, source='assistant')
             else:
-                print(f"Usage: fsm <event>")
+                print("Usage: fsm <event>")
         elif main_cmd in ["h", "help"]:
             self._display_help()
         elif main_cmd == "clear":

--- a/core/agent_comm.py
+++ b/core/agent_comm.py
@@ -1,6 +1,7 @@
 from datetime import datetime
 from core.shared_bus_manager import SharedBusManager
 
+
 class AgentComm:
     def __init__(self, agent_id: str):
         self.agent_id = agent_id

--- a/core/agent_comm_link.py
+++ b/core/agent_comm_link.py
@@ -1,14 +1,15 @@
 import os
-import json
 import time
 import random
 import logging
 from datetime import datetime
-from core.shared_bus_manager import SharedBusManager # Import SharedBusManager
+from core.shared_bus_manager import SharedBusManager  # Import SharedBusManager
 
 # --- CONFIGURATION ---
 # SHARED_BUS_FILE is now managed by SharedBusManager
-LOG_FILE = os.path.abspath(os.path.join(os.path.dirname(__file__), '..', 'logs', 'comm_link.log'))
+LOG_FILE = os.path.abspath(
+    os.path.join(os.path.dirname(__file__), '..', 'logs', 'comm_link.log')
+)
 UPDATE_INTERVAL = 3  # seconds
 
 # --- LOGGING SETUP ---

--- a/core/sensor_preprocessor.py
+++ b/core/sensor_preprocessor.py
@@ -93,6 +93,13 @@ class SensorPreprocessor:
         print("[Preprocessor] Returning cleaned sensor data.")
         return self.processed_data
 
+    def collect_statuses(self) -> dict:
+        """Return status of each sensor cluster."""
+        statuses = {}
+        for cluster, data in self.processed_data.items():
+            statuses[cluster] = data.get("status", "UNKNOWN")
+        return statuses
+
 def test():
     print("\n--- Running SensorPreprocessor Test ---")
 

--- a/sensors/sensor_bus.py
+++ b/sensors/sensor_bus.py
@@ -61,8 +61,16 @@ class SensorBus:
                 active_clusters = 0
 
                 for name, cluster in self.clusters.items():
-                    cluster.update()
-                    cluster.validate() # Run validation after update
+                    try:
+                        cluster.update()
+                    except Exception as e:  # noqa: BLE001
+                        cluster.data["status"] = "FAIL"
+                        cluster._add_error(f"Update failed: {e}")
+                        self._log(
+                            f"ERROR: Cluster '{cluster.get_name()}' update failed: {e}"
+                        )
+
+                    cluster.validate()  # Run validation after update
                     full_sensor_data[name] = cluster.serialize()
                     
                     status = cluster.data.get("status", "UNKNOWN")

--- a/tests/test_sensor_preprocessor.py
+++ b/tests/test_sensor_preprocessor.py
@@ -1,0 +1,17 @@
+import os
+import sys
+
+PROJECT_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), '..'))
+sys.path.append(PROJECT_ROOT)
+
+from core.sensor_preprocessor import SensorPreprocessor
+
+
+def test_collect_statuses():
+    raw = {
+        "cluster1": {"status": "OK", "errors": []},
+        "cluster2": {"status": "ERROR", "errors": ["x"]},
+    }
+    proc = SensorPreprocessor(raw)
+    statuses = proc.collect_statuses()
+    assert statuses == {"cluster1": "OK", "cluster2": "ERROR"}


### PR DESCRIPTION
## Summary
- log sensor cluster update failures and mark cluster status FAIL
- expose sensor cluster statuses via `collect_statuses`
- fix minor style issues in Assistant and AgentComm modules
- wrap long path in `agent_comm_link` and clean imports
- add unit test for `collect_statuses`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_687b179402e883318120766f40de0d28