### PR TITLE
Implement validated FSM client

### DIFF
--- a/core/fsm_client.py
+++ b/core/fsm_client.py
@@ -1,162 +1,85 @@
 # -*- coding: utf-8 -*-
+"""FSM Client
+Provides validated access to ``fsm_state.json`` and a helper to send events
+through the gatekeeper.
 """
-QIKI Bot
-FSM Client - Centralized and safe access to the bot's Finite State Machine.
-All reads and writes to fsm_state.json MUST go through this client.
-"""
+
 import json
 import os
-import fcntl
 import logging
-import time
-from typing import Dict, Any, Optional
+from datetime import datetime
+from typing import Any, Dict, Optional
+
+from core.file_paths import FSM_STATE_FILE
 from core.fsm_logger import log_transition
+from core.fsm_io import enqueue_event
 
-# --- Constants ---
-FSM_STATE_FILE = os.path.abspath(os.path.join(os.path.dirname(__file__), '..', 'fsm_state.json'))
-LOG_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), '..', 'logs'))
-FSM_ERROR_LOG_FILE = os.path.join(LOG_DIR, 'fsm_errors.log')
+# Paths
+BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+LOG_DIR = os.path.join(BASE_DIR, "logs")
+ERROR_LOG_FILE = os.path.join(LOG_DIR, "fsm_errors.log")
 
-# --- FSM Schema ---
-# Defines the required fields for a valid FSM state object.
-FSM_SCHEMA = {
-    "mode": str,
-    "task": str,
-    "status": str,
-    "last_event": str,
-    "timestamp": float,
-    "source": str,
-    "context": dict
-}
-
-# --- Logger Setup ---
-def setup_logger(name, log_file, level=logging.INFO):
-    """Function to setup as many loggers as you want"""
-    if not os.path.exists(LOG_DIR):
-        os.makedirs(LOG_DIR)
-        
-    handler = logging.FileHandler(log_file)        
-    handler.setFormatter(logging.Formatter('%(asctime)s - %(levelname)s - %(message)s'))
-    
-    logger = logging.getLogger(name)
-    logger.setLevel(level)
-    if not logger.handlers:
-        logger.addHandler(handler)
-    
-    return logger
-
-fsm_error_logger = setup_logger('fsm_error_logger', FSM_ERROR_LOG_FILE)
+# Allowed FSM states. In a real setup this could be loaded from a config file.
+FSM_SCHEMA = ["IDLE", "MISSION_ACTIVE", "CHARGING", "AVOIDING", "ERROR"]
 
 
 class FSMClient:
-    """
-    Provides a thread-safe and validated interface for interacting with fsm_state.json.
-    """
-    def __init__(self):
-        # Ensure the state file exists on initialization
-        if not os.path.exists(FSM_STATE_FILE):
-            self._initialize_state_file()
+    """Central access point to the FSM state."""
 
-    def _initialize_state_file(self):
-        """Creates a default FSM state file if it doesn't exist."""
-        initial_state = {
-            "mode": "idle",
-            "task": "none",
-            "status": "initialized",
-            "last_event": "init",
-            "timestamp": time.time(),
-            "source": "FSMClient",
-            "context": {}
-        }
+    def __init__(self, path: str = FSM_STATE_FILE) -> None:
+        self.path = path
+        self.schema = FSM_SCHEMA
+        self.state = self.load_state()
+
+    def load_state(self) -> Dict[str, Any]:
+        """Load state from disk. On failure return default state."""
         try:
-            with open(FSM_STATE_FILE, 'w') as f:
-                fcntl.flock(f, fcntl.LOCK_EX)
-                json.dump(initial_state, f, indent=2)
-                fcntl.flock(f, fcntl.LOCK_UN)
-            fsm_logger.info("Initialized FSM state file.")
-        except IOError as e:
-            fsm_error_logger.critical(f"Failed to initialize FSM state file: {e}")
-            raise
+            with open(self.path, "r") as f:
+                return json.load(f)
+        except Exception as exc:
+            self.log_error(f"Failed to load state: {exc}")
+            return {"state": "IDLE", "last_trigger": None, "context": {}}
 
-    def _validate_state(self, state_obj: Dict[str, Any]) -> bool:
-        """
-        Validates a state object against the FSM_SCHEMA.
-        Logs errors to fsm_errors.log.
-        """
-        missing_keys = [key for key in FSM_SCHEMA if key not in state_obj]
-        if missing_keys:
-            fsm_error_logger.error(f"State validation failed. Missing keys: {missing_keys}. State: {state_obj}")
-            return False
-        
-        type_errors = [
-            f"Key '{key}' has type {type(state_obj[key]).__name__}, expected {FSM_SCHEMA[key].__name__}"
-            for key in FSM_SCHEMA if not isinstance(state_obj.get(key), FSM_SCHEMA[key])
-        ]
-        if type_errors:
-            fsm_error_logger.error(f"State validation failed. Type mismatch: {', '.join(type_errors)}. State: {state_obj}")
-            return False
-            
-        return True
+    def save_state(self) -> None:
+        os.makedirs(os.path.dirname(self.path), exist_ok=True)
+        with open(self.path, "w") as f:
+            json.dump(self.state, f, indent=2)
 
     def get_state(self) -> Dict[str, Any]:
-        """
-        Safely reads and returns the current FSM state from the JSON file.
-        Uses a shared lock for concurrent reads.
-        """
-        try:
-            with open(FSM_STATE_FILE, 'r') as f:
-                fcntl.flock(f, fcntl.LOCK_SH)
-                try:
-                    state_data = json.load(f)
-                except json.JSONDecodeError:
-                    fsm_error_logger.error(f"Could not decode JSON from {FSM_STATE_FILE}. Returning error state.")
-                    state_data = {"state": "error", "reason": "json_decode_error"}
-                finally:
-                    fcntl.flock(f, fcntl.LOCK_UN)
-            return state_data
-        except IOError as e:
-            fsm_error_logger.error(f"Failed to read {FSM_STATE_FILE}: {e}. Returning error state.")
-            return {"state": "error", "reason": "io_error"}
+        """Return the currently cached state."""
+        return self.state
 
-    def set_state(self, state_obj: Dict[str, Any], *, trigger: Optional[str] = None, source: Optional[str] = None) -> bool:
-        """
-        Validates and safely writes a new state to the FSM file.
-        Uses an exclusive lock to prevent race conditions.
-        
-        Args:
-            state_obj: The new state dictionary to write.
-            trigger: The event or reason for the state change.
-            source: The module or component requesting the change.
-
-        Returns:
-            True if the state was set successfully, False otherwise.
-        """
-        # 1. Add metadata
-        state_obj['timestamp'] = time.time()
-        if source:
-            state_obj['source'] = source
-        if trigger:
-            state_obj['last_event'] = trigger
-
-        # 2. Validate the complete object
-        if not self._validate_state(state_obj):
+    def set_state(self, new_state: str, metadata: Dict[str, Any]) -> bool:
+        """Validate ``new_state`` and persist it with metadata."""
+        if new_state not in self.schema:
+            self.log_error(f"Invalid state '{new_state}'")
             return False
 
-        # 3. Get current state for logging
-        current_state = self.get_state()
-        from_state_summary = f"mode={current_state.get('mode')}, task={current_state.get('task')}, status={current_state.get('status')}"
-        to_state_summary = f"mode={state_obj.get('mode')}, task={state_obj.get('task')}, status={state_obj.get('status')}"
+        from_state = self.state.get("state", "UNKNOWN")
+        self.state = {
+            "state": new_state,
+            "last_trigger": metadata.get("trigger"),
+            "context": metadata.get("context", {}),
+            "timestamp": datetime.now().isoformat(),
+        }
+        self.save_state()
+        self.log_transition(from_state, new_state, metadata)
+        return True
 
-        # 4. Write to file with exclusive lock
-        try:
-            with open(FSM_STATE_FILE, 'w') as f:
-                fcntl.flock(f, fcntl.LOCK_EX)
-                json.dump(state_obj, f, indent=2)
-                fcntl.flock(f, fcntl.LOCK_UN)
-            
-            # 5. Log the successful transition
-            log_transition(current_state, state_obj, trigger, source)
-            return True
-        except IOError as e:
-            fsm_error_logger.error(f"Failed to write state to {FSM_STATE_FILE}, requested by '{source}': {e}")
-            return False
+    # --- Logging helpers -------------------------------------------------
+    def log_transition(self, from_s: str, to_s: str, meta: Dict[str, Any]) -> None:
+        log_transition({"state": from_s}, {"state": to_s}, meta.get("trigger"), meta.get("source"))
+
+    def log_error(self, msg: str) -> None:
+        os.makedirs(LOG_DIR, exist_ok=True)
+        with open(ERROR_LOG_FILE, "a") as f:
+            f.write(f"{datetime.now().isoformat()} - {msg}\n")
+
+    # --- Event helper ----------------------------------------------------
+    def send_event(self, event: str, source: str, metadata: Optional[Dict[str, Any]] = None) -> None:
+        enqueue_event(event, source, metadata)
+
+
+def send_event(event: str, source: str, metadata: Optional[Dict[str, Any]] = None) -> None:
+    """Convenience wrapper around :func:`enqueue_event`."""
+    enqueue_event(event, source, metadata)

--- a/core/fsm_interface.py
+++ b/core/fsm_interface.py
@@ -48,7 +48,8 @@ class FSMInterface:
         """Exports the current FSM state and writes it to the JSON file using FSMClient."""
         state_dict = self.fsm.export_state()
         fsm_client = FSMClient()
-        fsm_client.set_state(state_dict, source="FSMInterface", trigger="sync_to_disk")
+        meta = {"trigger": "sync_to_disk", "context": state_dict, "source": "FSMInterface"}
+        fsm_client.set_state(state_dict.get("current_state", "UNKNOWN"), meta)
 
     def trigger_event(self, event, meta=None):
         """

--- a/core/rule_engine.py
+++ b/core/rule_engine.py
@@ -237,7 +237,8 @@ if __name__ == "__main__":
     
     if not os.path.exists(FSM_STATE_FILE):
         fsm = FSMClient()
-        fsm.set_state({"state": "idle", "mode": "idle", "task": "none", "status": "ok", "last_event": "init", "timestamp": time.time(), "source": "rule_engine"})
+        meta = {"trigger": "init", "context": {}, "source": "rule_engine"}
+        fsm.set_state("IDLE", meta)
 
     engine = RuleEngine()
     


### PR DESCRIPTION
## Summary
- rewrite FSMClient with validation and logging
- adapt FSMInterface and RuleEngine to new API

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687b4057844c8331b6bfc27ae2506019

## Summary by Sourcery

Refactor FSMClient to validate states, cache state in memory, and centralize logging, and update FSMInterface and RuleEngine to its new set_state API

Enhancements:
- Refactor FSMClient to load state into memory, persist via save_state, and validate transitions against a predefined schema
- Centralize transition and error logging using log_transition and log_error helpers with dedicated log files
- Introduce send_event convenience wrapper around enqueue_event for dispatching FSM events
- Adapt FSMInterface and RuleEngine to call FSMClient.set_state with state name and metadata